### PR TITLE
Change option syntax to use hrpc prefix

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -86,14 +86,12 @@ const camelize = (name) => {
 }
 
 const serviceId = service => {
-  if (service.options.id) return Number(service.options.id)
-  if (service.options['hrpc.service_id']) return Number(service.options['hrpc.service_id'])
+  if (service.options['hrpc.service']) return Number(service.options['hrpc.service'])
   return null
 }
 
 const methodId = method => {
-  if (method.options.id) return Number(method.options.id)
-  if (method.options['hrpc.id']) return Number(method.options['hrpc.id'])
+  if (method.options['hrpc.method']) return Number(method.options['hrpc.method'])
   return null
 }
 

--- a/bin.js
+++ b/bin.js
@@ -86,11 +86,13 @@ const camelize = (name) => {
 }
 
 const serviceId = service => {
+  if (service.options.id) return Number(service.options.id)
   if (service.options['hrpc.service']) return Number(service.options['hrpc.service'])
   return null
 }
 
 const methodId = method => {
+  if (method.options.id) return Number(method.options.id)
   if (method.options['hrpc.method']) return Number(method.options['hrpc.method'])
   return null
 }

--- a/example/rpc.js
+++ b/example/rpc.js
@@ -18,16 +18,16 @@ const errorEncoding = {
 
 class HRPCServiceTest {
   constructor (rpc) {
-    const service = rpc.defineService({ id: 1 })
+    const service = rpc.defineService({ id: 2 })
 
     this._test = service.defineMethod({
-      id: 1,
+      id: 5,
       requestEncoding: messages.TestRequest,
       responseEncoding: messages.TestResponse
     })
 
     this._boring = service.defineMethod({
-      id: 2,
+      id: 6,
       requestEncoding: RPC.NULL,
       responseEncoding: RPC.NULL
     })

--- a/example/services.proto
+++ b/example/services.proto
@@ -7,6 +7,7 @@ message TestResponse {
 }
 
 service Test {
-  rpc Test (TestRequest) returns (TestResponse) { option id = 1; }
+  option (hrpc.service) = 2;
+  rpc Test (TestRequest) returns (TestResponse) { option (hrpc.method) = 5; }
   rpc Boring (NULL) returns (NULL) {}
 }


### PR DESCRIPTION
The current way options are set (`id` for services and methods) unfortunately makes the `protoc` compiler reject the schema. This changes the options to use `hrpc.service` and `hrpc.method`, which can be supported in the `protoc` compiler when importing a `hrpc.proto` that looks [like this](https://gist.github.com/Frando/45a735baa954ba8abae56c76af6fc74b).